### PR TITLE
Allows children to be directly added to parent's belongs_to

### DIFF
--- a/lib/citier/child_instance_methods.rb
+++ b/lib/citier/child_instance_methods.rb
@@ -1,6 +1,6 @@
 module ChildInstanceMethods
 
-  def save
+  def save(validate = true)
     return false unless self.valid?
 
     #get the attributes of the class which are inherited from it's parent.

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -47,6 +47,7 @@ module ClassMethods
       end
 
       def self.find(*args) #overrides find to get all attributes
+
         tuples = super
 
         # in case of many objects, return an array of them, reloaded to pull in inherited attributes

--- a/lib/citier/core_ext.rb
+++ b/lib/citier/core_ext.rb
@@ -47,3 +47,29 @@ def drop_citier_view(theclass) #function for dropping views for migrations
   citier_debug("Dropping citier view -> #{sql}")
   theclass.connection.execute sql
 end
+
+def update_citier_view(theclass) #function for updating views for migrations
+  
+  citier_debug("Updating citier view for #{theclass}")
+  
+  if theclass.table_exists?
+    drop_citier_view(theclass)
+    create_citier_view(theclass)
+  else
+    citier_debug("Error: #{theclass} VIEW doesn't exist.")
+  end
+  
+end
+
+def create_or_update_citier_view(theclass) #Convienience function for updating or creating views for migrations
+  
+  citier_debug("Create or Update citier view for #{theclass}")
+  
+  if theclass.table_exists?
+    update_citier_view(theclass)
+  else
+    citier_debug("VIEW DIDN'T EXIST. Now creating for #{theclass}")
+    create_citier_view(theclass)
+  end
+  
+end


### PR DESCRIPTION
Addresses this problem:

Site.first.products << Book.first

Where

Site
:has_many :products

Product
:belongs_to :site

And

class Book < Product
acts_as_citier

Throws an error:

ArgumentError: wrong number of arguments (1 for 0)
from /Users/danmorgz/.rvm/gems/ruby-1.9.2-p0@rails3/gems/citier-0.1.12/lib/citier/child_instance_methods.rb:3:in save'
from /Users/danmorgz/.rvm/gems/ruby-1.9.2-p0@rails3/gems/activerecord-3.0.9/lib/active_record/associations/has_many_association.rb:66:ininsert_record'
