### PR TITLE
Fixed issues #9, #13, #26, #27, #28, #29, #30, and some more.

### DIFF
--- a/lib/citier/child_instance_methods.rb
+++ b/lib/citier/child_instance_methods.rb
@@ -94,7 +94,7 @@ module Citier
   
     def save!(options={})
       raise ActiveRecord::RecordInvalid.new(self) if (options[:validate] != false && !self.valid?)
-      self.save || raise ActiveRecord::RecordNotSaved
+      self.save || raise(ActiveRecord::RecordNotSaved)
     end
 
     include InstanceMethods

--- a/lib/citier/child_instance_methods.rb
+++ b/lib/citier/child_instance_methods.rb
@@ -1,95 +1,95 @@
 module Citier
   module ChildInstanceMethods
 
-    def save(validate = true)
-      return false unless self.valid?
+    def save(options={})
+      return false if (options[:validate] != false && !self.valid?)
     
       #citier_debug("Callback (#{self.inspect})")
       citier_debug("SAVING #{self.class.to_s}")
     
-      #Just run before save callbacks
       #AIT NOTE: Will change any protected values back to original values so any models onwards won't see changes.
-      self.run_callbacks(:save){ false }
+      # Run save and create/update callbacks, just like ActiveRecord does
+      self.run_callbacks(:save) do
+        self.run_callbacks(self.new_record? ? :create : :update) do
+          #get the attributes of the class which are inherited from it's parent.
+          attributes_for_parent = self.attributes.reject { |key,value| !self.class.superclass.column_names.include?(key) }
+          changed_attributes_for_parent = self.changed_attributes.reject { |key,value| !self.class.superclass.column_names.include?(key) }
+
+          # Get the attributes of the class which are unique to this class and not inherited.
+          attributes_for_current = self.attributes.reject { |key,value| self.class.superclass.column_names.include?(key) }
+          changed_attributes_for_current = self.changed_attributes.reject { |key,value| self.class.superclass.column_names.include?(key) }
+
+          citier_debug("Attributes for #{self.class.superclass.to_s}: #{attributes_for_parent.inspect}")
+          citier_debug("Changed attributes for #{self.class.superclass.to_s}: #{changed_attributes_for_parent.keys.inspect}")
+          citier_debug("Attributes for #{self.class.to_s}: #{attributes_for_current.inspect}")
+          citier_debug("Changed attributes for #{self.class.to_s}: #{changed_attributes_for_current.keys.inspect}")
+
+          ########
+          #
+          # Parent saving
     
-      #get the attributes of the class which are inherited from it's parent.
-      attributes_for_parent = self.attributes.reject { |key,value| !self.class.superclass.column_names.include?(key) }
-      changed_attributes_for_parent = self.changed_attributes.reject { |key,value| !self.class.superclass.column_names.include?(key) }
-
-      # Get the attributes of the class which are unique to this class and not inherited.
-      attributes_for_current = self.attributes.reject { |key,value| self.class.superclass.column_names.include?(key) }
-      changed_attributes_for_current = self.changed_attributes.reject { |key,value| self.class.superclass.column_names.include?(key) }
-
-      citier_debug("Attributes for #{self.class.superclass.to_s}: #{attributes_for_parent.inspect}")
-      citier_debug("Changed attributes for #{self.class.superclass.to_s}: #{changed_attributes_for_parent.keys.inspect}")
-      citier_debug("Attributes for #{self.class.to_s}: #{attributes_for_current.inspect}")
-      citier_debug("Changed attributes for #{self.class.to_s}: #{changed_attributes_for_current.keys.inspect}")
-
-      ########
-      #
-      # Parent saving
-    
-      #create a new instance of the superclass, passing the inherited attributes.
-      parent = self.class.superclass.new
+          #create a new instance of the superclass, passing the inherited attributes.
+          parent = self.class.superclass.new
       
-      parent.force_attributes(attributes_for_parent, :merge => true)
-      changed_attributes_for_parent["id"] = 0 # We need to change at least something to force a timestamps update.
-      parent.force_changed_attributes(changed_attributes_for_parent)
+          parent.force_attributes(attributes_for_parent, :merge => true)
+          changed_attributes_for_parent["id"] = 0 # We need to change at least something to force a timestamps update.
+          parent.force_changed_attributes(changed_attributes_for_parent)
       
-      parent.id = self.id if id
-      parent.type = self.type
+          parent.id = self.id if id
+          parent.type = self.type
     
-      parent.is_new_record(new_record?)
+          parent.is_new_record(new_record?)
       
-      # If we're root (AR subclass) this will just be saved as normal through AR. If we're a child it will call this method again. 
-      # It will try and save it's parent and then save itself through the Writable constant.
-      parent_saved = parent.save
-      self.id = parent.id
+          # If we're root (AR subclass) this will just be saved as normal through AR. If we're a child it will call this method again. 
+          # It will try and save it's parent and then save itself through the Writable constant.
+          parent_saved = parent.save
+          self.id = parent.id
 
-      if(parent_saved==false)
-        # Couldn't save parent class
-        # TODO: Handle situation where parent class could not be saved
-        citier_debug("Class (#{self.class.superclass.to_s}) could not be saved")
-      end
+          if !parent_saved
+            # Couldn't save parent class
+            citier_debug("Class (#{self.class.superclass.to_s}) could not be saved")
+            citier_debug("Errors = #{parent.errors.to_s}")
+            return false # Return false and exit run_callbacks :save and :create/:update, so the after_ callback won't run.
+          end
     
-      #End of parent saving
+          #End of parent saving
     
-      ######
-      ##
-      ## Self Saving
-      ##
+          ######
+          ##
+          ## Self Saving
+          ##
 
-      # If there are attributes for the current class (unique & not inherited) 
-      # and parent(s) saved successfully, save current model
-      if(!attributes_for_current.empty? && parent_saved)
-       
-        current = self.class::Writable.new
+          # If there are attributes for the current class (unique & not inherited), save current model
+          if !attributes_for_current.empty?
+            current = self.class::Writable.new
         
-        current.force_attributes(attributes_for_current, :merge => true)
-        current.force_changed_attributes(changed_attributes_for_current)
+            current.force_attributes(attributes_for_current, :merge => true)
+            current.force_changed_attributes(changed_attributes_for_current)
         
-        current.id = self.id
-        current.is_new_record(new_record?)
+            current.id = self.id
+            current.is_new_record(new_record?)
       
-        current_saved = current.save
-      
-        #self.run_callbacks(:save){ false } #Run the after save callback
-        # Rails 3 doesn't yet have a way of only called AFTER save callback
-        current.after_save_change_request if current.respond_to?('after_save_change_request') #Specific to an app I'm building
-      
-        # This is no longer a new record
-        is_new_record(false)
+            current_saved = current.save
+            
+            current.after_save_change_request if current.respond_to?('after_save_change_request') #Specific to an app I'm building
 
-        if(!current_saved)
-          citier_debug("Class (#{self.class.superclass.to_s}) could not be saved")
-          citier_debug("Errors = #{current.errors.to_s}")
+            if !current_saved
+              citier_debug("Class (#{self.class.superclass.to_s}) could not be saved")
+              citier_debug("Errors = #{current.errors.to_s}")
+              return false # Return false and exit run_callbacks :save and :create/:update, so the after callback won't run.
+            end
+          end  
+
+          # at this point, parent_saved && current_saved
+          
+          is_new_record(false) # This is no longer a new record
+
+          self.force_changed_attributes({}) # Reset changed_attributes so future changes will be tracked correctly
+          
+          # No return, because we want the after callback to run.
         end
       end
-
-      if parent_saved && current_saved
-        self.force_changed_attributes({})
-      end
-      
-      return parent_saved && current_saved
+      return true
     end
   
     def save!

--- a/lib/citier/child_instance_methods.rb
+++ b/lib/citier/child_instance_methods.rb
@@ -92,12 +92,10 @@ module Citier
       return true
     end
   
-    def save!
-      raise ActiveRecord::RecordInvalid.new(self) unless self.valid?
-      self.save
+    def save!(options={})
+      raise ActiveRecord::RecordInvalid.new(self) if (options[:validate] != false && !self.valid?)
+      self.save || raise ActiveRecord::RecordNotSaved
     end
-  
-  
 
     include InstanceMethods
   end

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -35,8 +35,6 @@ module Citier
       else
       # Root class
 
-        after_save :updatetype
-
         citier_debug("Root Class")
 
         set_table_name "#{table_name}"

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -42,16 +42,15 @@ module Citier
         citier_debug("table_name -> #{self.table_name}")
 
         def self.find(*args) #overrides find to get all attributes
-
           tuples = super
+          tuples_class = tuples.kind_of?(Array) ? tuples.first.class : tuples.class
+          return tuples if self == tuples_class
 
           # in case of many objects, return an array of them, reloaded to pull in inherited attributes
-          return tuples.map{|x| x.reload} if tuples.kind_of?(Array)
+          return tuples.map { |x| x.reload } if tuples.kind_of?(Array)
 
           # in case of only one tuple, return it reloaded.
-          # Can't use reload as would loop inifinitely, so do a search by id instead.
-          # Probably a nice way of cleaning this a bit
-          return tuples.class.where(tuples.class[:id].eq(tuples.id))[0]
+          return tuples.reload
         end
 
         # Add the functions required for root classes only

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -52,7 +52,7 @@ module Citier
             ids_wanted = {}
             
             # Map all the ids wanted per type
-            tuples.each_with_index do |tuple, index|
+            tuples.each do |tuple|
               if tuple.class == self # We don't need to find the record again if this is already the correct one
                 found_records << tuple
                 next

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -42,7 +42,15 @@ module Citier
         citier_debug("table_name -> #{self.table_name}")
 
         def self.find(*args) #overrides find to get all attributes
+          # With option :no_children set to true, only records of type self will be returned. 
+          # So Root.all(:no_children => true) won't return Child records.
+          options = args.last.is_a?(Hash) ? args.last : {}
+          no_children = options.delete(:no_children)
+          self_type = self.superclass == ActiveRecord::Base ? nil : self.name
+          return self.where(:type => self_type).find(*args) if no_children
+          
           tuples = super
+          
           # If the tuple is already of this class's type, we don't need to reload it.
           return tuples if tuples.kind_of?(Array) ? tuples.all? { |tuple| tuple.class == self } : (tuples.class == self) 
           

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -25,6 +25,10 @@ module Citier
         # The the Writable. References the write-able table for the class because
         # save operations etc can't take place on the views
         self.const_set("Writable", create_class_writable(self))
+        
+        after_initialize do
+          self.id = nil if self.new_record? && self.id == 0
+        end
 
         # Add the functions required for children only
         send :include, Citier::ChildInstanceMethods

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -77,12 +77,12 @@ module Citier
             end
             
             # Make a new array with the found records at the right places
-            reloaded_tuples = []
-            tuples.each do |tuple|
-              reloaded_tuples << found_records.find { |found| found.id == tuple.id }
+            tuples.each do |tuple|              
+              found_record = found_records.find { |found| found.id == tuple.id }
+              tuple.force_attributes(found_record.instance_variable_get(:@attributes), :merge => true, :clear_caches => false)
             end
             
-            return reloaded_tuples
+            return tuples
           end
 
           # In case of only one tuple, return it reloaded.

--- a/lib/citier/core_ext.rb
+++ b/lib/citier/core_ext.rb
@@ -15,6 +15,8 @@ class ActiveRecord::Base
 
   def self.create_class_writable(class_reference)  #creation of a new class which inherits from ActiveRecord::Base
     Class.new(ActiveRecord::Base) do
+      include Citier::InstanceMethods::ForcedWriters
+      
       t_name = class_reference.table_name
       t_name = t_name[5..t_name.length]
 

--- a/lib/citier/core_ext.rb
+++ b/lib/citier/core_ext.rb
@@ -8,9 +8,15 @@ class ActiveRecord::Base
     @new_record = state
   end
   
+  # For some reason need to override this so it uses my modified find function which reloads each object to pull in all properties.
   def self.all(*args)
-    # For some reason need to override this so it uses my modified find function which reloads each object to pull in all properties.
     return find(:all, *args)
+  end
+  def self.first(*args)
+    return find(:first, *args)
+  end
+  def self.last(*args)
+    return find(:last, *args)
   end
 
   def self.create_class_writable(class_reference)  #creation of a new class which inherits from ActiveRecord::Base

--- a/lib/citier/core_ext.rb
+++ b/lib/citier/core_ext.rb
@@ -1,4 +1,12 @@
-class ActiveRecord::Base  
+class ActiveRecord::Base 
+  
+  def self.set_acts_as_citier(citier)
+    @acts_as_citier = citier
+  end
+  
+  def self.acts_as_citier?
+    @acts_as_citier || false
+  end
 
   def self.[](column_name) 
     arel_table[column_name]
@@ -6,17 +14,6 @@ class ActiveRecord::Base
 
   def is_new_record(state)
     @new_record = state
-  end
-  
-  # For some reason need to override this so it uses my modified find function which reloads each object to pull in all properties.
-  def self.all(*args)
-    return find(:all, *args)
-  end
-  def self.first(*args)
-    return find(:first, *args)
-  end
-  def self.last(*args)
-    return find(:last, *args)
   end
 
   def self.create_class_writable(class_reference)  #creation of a new class which inherits from ActiveRecord::Base

--- a/lib/citier/instance_methods.rb
+++ b/lib/citier/instance_methods.rb
@@ -18,16 +18,6 @@ module Citier
         @changed_attributes = new_changed_attributes
       end
     end
-
-    def updatetype 
-      # Keeps our types intact when we've retrieved a record through Root.first etc. and save it.
-      # Without this it would revert back to the root class
-      type = self.type || self.class.to_s
-           
-      sql = "UPDATE #{self.class.base_class.table_name} SET #{self.class.inheritance_column} = '#{type}' WHERE id = #{self.id}"
-      self.connection.execute(sql)
-      citier_debug("#{sql}")
-    end
   
     # USAGE validates :attribute, :citier_uniqueness => true
     # Needed because validates :attribute, :uniqueness => true  Won't work because it tries to call child_class.attribute on parents table

--- a/lib/citier/instance_methods.rb
+++ b/lib/citier/instance_methods.rb
@@ -8,9 +8,12 @@ module Citier
       def force_attributes(new_attributes, options = {})
         new_attributes = @attributes.merge(new_attributes) if options[:merge]
         @attributes = new_attributes
-        @aggregation_cache = {}
-        @association_cache = {}
-        @attributes_cache = {}
+        
+        if options[:clear_caches] != false
+          @aggregation_cache = {}
+          @association_cache = {}
+          @attributes_cache = {}
+        end
       end
     
       def force_changed_attributes(new_changed_attributes, options = {})

--- a/lib/citier/instance_methods.rb
+++ b/lib/citier/instance_methods.rb
@@ -1,5 +1,23 @@
 module Citier
-  module InstanceMethods
+  module InstanceMethods    
+    def self.included(base)
+      base.send :include, ForcedWriters
+    end
+    
+    module ForcedWriters
+      def force_attributes(new_attributes, options = {})
+        new_attributes = @attributes.merge(new_attributes) if options[:merge]
+        @attributes = new_attributes
+        @aggregation_cache = {}
+        @association_cache = {}
+        @attributes_cache = {}
+      end
+    
+      def force_changed_attributes(new_changed_attributes, options = {})
+        new_changed_attributes = @attributes.merge(new_changed_attributes) if options[:merge]
+        @changed_attributes = new_changed_attributes
+      end
+    end
 
     def updatetype 
       # Keeps our types intact when we've retrieved a record through Root.first etc. and save it.

--- a/lib/citier/relation_methods.rb
+++ b/lib/citier/relation_methods.rb
@@ -83,8 +83,10 @@ module ActiveRecord
       no_children = options.delete(:no_children)
       if no_children
         relation = clone
+
+        c = @klass
         
-        self_type = self.superclass == ActiveRecord::Base ? nil : self.name
+        self_type = c.superclass == ActiveRecord::Base ? nil : c.name
         relation = relation.where(:type => self_type)
       end
       

--- a/lib/citier/relation_methods.rb
+++ b/lib/citier/relation_methods.rb
@@ -76,16 +76,19 @@ module ActiveRecord
     def apply_finder_options(options)
       return relation_apply_finder_options(options) if !@klass.acts_as_citier?
       
-      puts "Using custom apply_finder_options!"
+      relation = self
+      
       # With option :no_children set to true, only records of type self will be returned. 
       # So Root.all(:no_children => true) won't return Child records.
       no_children = options.delete(:no_children)
       if no_children
+        relation = clone
+        
         self_type = self.superclass == ActiveRecord::Base ? nil : self.name
-        options[:conditions] = (options[:conditions] || {}).merge( :type => self_type )
+        relation = relation.where(:type => self_type)
       end
       
-      relation_apply_finder_options(options)
+      relation.relation_apply_finder_options(options)
     end
   end
 end

--- a/lib/citier/relation_methods.rb
+++ b/lib/citier/relation_methods.rb
@@ -3,33 +3,89 @@ module ActiveRecord
     
     alias_method :relation_delete_all, :delete_all
     def delete_all(conditions = nil)
-      if conditions
-        relation_delete_all(conditions)
-      else
-        deleted = true
-        ids = nil
-        c = @klass
-        
-        bind_values.each do |bind_value|
-          if bind_value[0].name == "id"
-            ids = bind_value[1]
-            break
-          end
-        end
-        ids ||= where_values_hash["id"] || where_values_hash[:id]
-        where_hash = ids ? { :id => ids } : nil
-        
-        deleted &= c.base_class.where(where_hash).relation_delete_all
-        while c.superclass != ActiveRecord::Base
-          if c.const_defined?(:Writable)
-            citier_debug("Deleting back up hierarchy #{c}")
-            deleted &= c::Writable.where(where_hash).delete_all
-          end
-          c = c.superclass
-        end
-        deleted
-      end
-    end
+      return relation_delete_all(conditions) if !@klass.acts_as_citier?
+      
+      return relation_delete_all(conditions) if conditions
 
+      deleted = true
+      ids = nil
+      c = @klass
+      
+      bind_values.each do |bind_value|
+        if bind_value[0].name == "id"
+          ids = bind_value[1]
+          break
+        end
+      end
+      ids ||= where_values_hash["id"] || where_values_hash[:id]
+      where_hash = ids ? { :id => ids } : nil
+      
+      deleted &= c.base_class.where(where_hash).relation_delete_all
+      while c.superclass != ActiveRecord::Base
+        if c.const_defined?(:Writable)
+          citier_debug("Deleting back up hierarchy #{c}")
+          deleted &= c::Writable.where(where_hash).delete_all
+        end
+        c = c.superclass
+      end
+      
+      deleted
+    end
+    
+    alias_method :relation_to_a, :to_a
+    def to_a
+      return relation_to_a if !@klass.acts_as_citier?
+      
+      records = relation_to_a
+      
+      c = @klass
+      
+      if records.all? { |record| record.class == c } 
+        return records 
+      end
+      
+      full_records = []
+      ids_wanted = {}
+      
+      # Map all the ids wanted per type
+      records.each do |record|
+        if record.class == c # We don't need to find the record again if this is already the correct one
+          full_records << record
+          next
+        end
+        
+        ids_wanted[record.class] ||= []
+        ids_wanted[record.class] << record.id
+      end
+      
+      # Find all wanted records
+      ids_wanted.each do |type_class, ids|
+        full_records.push(*type_class.find(ids))
+      end
+      
+      # Make a new array with the found records at the right places
+      records.each do |record|              
+        full_record = full_records.find { |full_record| full_record.id == record.id }
+        record.force_attributes(full_record.instance_variable_get(:@attributes), :merge => true, :clear_caches => false)
+      end
+      
+      return records
+    end
+    
+    alias_method :relation_apply_finder_options, :apply_finder_options
+    def apply_finder_options(options)
+      return relation_apply_finder_options(options) if !@klass.acts_as_citier?
+      
+      puts "Using custom apply_finder_options!"
+      # With option :no_children set to true, only records of type self will be returned. 
+      # So Root.all(:no_children => true) won't return Child records.
+      no_children = options.delete(:no_children)
+      if no_children
+        self_type = self.superclass == ActiveRecord::Base ? nil : self.name
+        options[:conditions] = (options[:conditions] || {}).merge( :type => self_type )
+      end
+      
+      relation_apply_finder_options(options)
+    end
   end
 end

--- a/lib/citier/sql_adapters.rb
+++ b/lib/citier/sql_adapters.rb
@@ -6,118 +6,126 @@
 #------------------------------------------------------------------------------------------------#
 
 require 'active_record'
-require 'active_record/connection_adapters/sqlite_adapter'
-require 'active_record/connection_adapters/sqlite3_adapter'
-require 'active_record/connection_adapters/postgresql_adapter'
 
 # SQLite
-module ActiveRecord
-  module ConnectionAdapters
-    class SQLiteAdapter < AbstractAdapter
+begin
+  require 'active_record/connection_adapters/sqlite_adapter'
+  require 'active_record/connection_adapters/sqlite3_adapter'
+  
+  module ActiveRecord
+    module ConnectionAdapters
+      class SQLiteAdapter < AbstractAdapter
 
-      def tables(name = nil) 
-        sql = <<-SQL
-        SELECT name
-        FROM sqlite_master
-        WHERE (type = 'table' or type='view') AND NOT name = 'sqlite_sequence'
-        SQL
-        # Modification : the where clause was intially WHERE type = 'table' AND NOT name = 'sqlite_sequence' 
-        #                now it is WHERE (type = 'table' or type='view') AND NOT name = 'sqlite_sequence'
-        # this modification is made to consider tables AND VIEWS as tables
+        def tables(name = nil) 
+          sql = <<-SQL
+          SELECT name
+          FROM sqlite_master
+          WHERE (type = 'table' or type='view') AND NOT name = 'sqlite_sequence'
+          SQL
+          # Modification : the where clause was intially WHERE type = 'table' AND NOT name = 'sqlite_sequence' 
+          #                now it is WHERE (type = 'table' or type='view') AND NOT name = 'sqlite_sequence'
+          # this modification is made to consider tables AND VIEWS as tables
 
-        execute(sql, name).map do |row|
-          row['name']
+          execute(sql, name).map do |row|
+            row['name']
+          end
         end
       end
     end
-  end
-
+  end  
+rescue Gem::LoadError
+  # not installed
 end
 
-
 # PostGreSQL
-module ActiveRecord
-  module ConnectionAdapters
-    class PostgreSQLAdapter < AbstractAdapter
-      def tables(name = nil)
-        a=tablesL(name)
-        b=viewsL(name)
-        if(b!=[])
-          a=a+b
-        end
-        return a
-      end
-
-      def tablesL(name = nil)
-
-        query(<<-SQL, name).map { |row| row[0] }
-        SELECT tablename
-        FROM pg_tables
-        WHERE schemaname = ANY (current_schemas(false))
-        SQL
-      end
-      def viewsL(name = nil)
-
-        query(<<-SQL, name).map { |row| row[0] }
-        SELECT viewname
-        FROM pg_views
-        WHERE schemaname = ANY (current_schemas(false))
-        SQL
-      end
-
-      def table_exists?(name)
-        a=table_existsB?(name)
-        b=views_existsB?(name)
-        return a||b
-      end
-
-
-      def table_existsB?(name)
-        name          = name.to_s
-        schema, table = name.split('.', 2)
-
-        unless table # A table was provided without a schema
-          table  = schema
-          schema = nil
+begin
+  require 'active_record/connection_adapters/postgresql_adapter'
+  
+  module ActiveRecord
+    module ConnectionAdapters
+      class PostgreSQLAdapter < AbstractAdapter
+        def tables(name = nil)
+          a=tablesL(name)
+          b=viewsL(name)
+          if(b!=[])
+            a=a+b
+          end
+          return a
         end
 
-        if name =~ /^"/ # Handle quoted table names
-          table  = name
-          schema = nil
+        def tablesL(name = nil)
+
+          query(<<-SQL, name).map { |row| row[0] }
+          SELECT tablename
+          FROM pg_tables
+          WHERE schemaname = ANY (current_schemas(false))
+          SQL
+        end
+        def viewsL(name = nil)
+
+          query(<<-SQL, name).map { |row| row[0] }
+          SELECT viewname
+          FROM pg_views
+          WHERE schemaname = ANY (current_schemas(false))
+          SQL
         end
 
-        query(<<-SQL).first[0].to_i > 0
-        SELECT COUNT(*)
-        FROM pg_tables
-        WHERE tablename = '#{table.gsub(/(^"|"$)/,'')}'
-        #{schema ? "AND schemaname = '#{schema}'" : ''}
-        SQL
-
-      end
-      def views_existsB?(name)
-        name          = name.to_s
-        schema, table = name.split('.', 2)
-
-        unless table # A table was provided without a schema
-          table  = schema
-          schema = nil
+        def table_exists?(name)
+          a=table_existsB?(name)
+          b=views_existsB?(name)
+          return a||b
         end
 
-        if name =~ /^"/ # Handle quoted table names
-          table  = name
-          schema = nil
+
+        def table_existsB?(name)
+          name          = name.to_s
+          schema, table = name.split('.', 2)
+
+          unless table # A table was provided without a schema
+            table  = schema
+            schema = nil
+          end
+
+          if name =~ /^"/ # Handle quoted table names
+            table  = name
+            schema = nil
+          end
+
+          query(<<-SQL).first[0].to_i > 0
+          SELECT COUNT(*)
+          FROM pg_tables
+          WHERE tablename = '#{table.gsub(/(^"|"$)/,'')}'
+          #{schema ? "AND schemaname = '#{schema}'" : ''}
+          SQL
+
         end
+        def views_existsB?(name)
+          name          = name.to_s
+          schema, table = name.split('.', 2)
 
-        query(<<-SQL).first[0].to_i > 0
-        SELECT COUNT(*)
-        FROM pg_views
-        WHERE viewname = '#{table.gsub(/(^"|"$)/,'')}'
-        #{schema ? "AND schemaname = '#{schema}'" : ''}
-        SQL
+          unless table # A table was provided without a schema
+            table  = schema
+            schema = nil
+          end
 
+          if name =~ /^"/ # Handle quoted table names
+            table  = name
+            schema = nil
+          end
+
+          query(<<-SQL).first[0].to_i > 0
+          SELECT COUNT(*)
+          FROM pg_views
+          WHERE viewname = '#{table.gsub(/(^"|"$)/,'')}'
+          #{schema ? "AND schemaname = '#{schema}'" : ''}
+          SQL
+
+        end
       end
     end
-  end
+  end  
+rescue Gem::LoadError
+  # not installed
 end
 
 # MySQL


### PR DESCRIPTION
913c3c0 is a fix to #28
81b2b17 is a fix to #29
4a7cc8c is a fix to #13
7c8f74a is a fix to #30
8b595a4 + 294d6a2 is a fix to #27
f6d8abd is a fix to #26
801b76e is mentioned [here](https://github.com/Rexly/citier/pull/1)
51aa7dc + 6ddc33d + 2a61bbd is a fix to #9

Before the patch in d2894a2, changes that caused a child's value to be equal to the default value were not included in the UPDATE query, causing the database not to have to correct data. This fixes that by copying over the child's @changed_attributes, so that child::Writable knows what actually needs to be committed.
