### PR TITLE
Fixes for Rails 3.2

### DIFF
--- a/citier.gemspec
+++ b/citier.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{citier}
-  s.version = "0.1.14"
+  s.version = "0.1.15"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Peter Hamilton, Originally from Laurent Buffat, Pierre-Emmanuel Jouve"]
-  s.date = %q{2011-04-29}
+  s.date = %q{2012-01-08}
   s.description = %q{CITIER (Class Inheritance & Table Inheritance Embeddings for Rails) is a solution for single and multiple class table inheritance.
     For full information: http://peterhamilton.github.com/citier/
     For the original version by ALTRABio see www.github.com/altrabio/}

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -19,7 +19,7 @@ module Citier
         citier_debug("table_name -> #{table_name}")
 
         # Set up the table which contains ALL attributes we want for this class
-        set_table_name "view_#{table_name}"
+        self.table_name = "view_#{table_name}"
 
         citier_debug("tablename (view) -> #{self.table_name}")
 

--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -10,7 +10,7 @@ module Citier
       #:table_name = option for setting the name of the current class table_name, default value = 'tableized(current class name)'
       table_name = (options[:table_name] || self.name.tableize.gsub(/\//,'_')).to_s
 
-      set_inheritance_column "#{db_type_field}"
+      self.inheritance_column = "#{db_type_field}"
 
       if(self.superclass!=ActiveRecord::Base)
         # Non root-class
@@ -38,7 +38,7 @@ module Citier
 
         citier_debug("Root Class")
 
-        set_table_name "#{table_name}"
+        self.table_name = "#{table_name}"
 
         citier_debug("table_name -> #{self.table_name}")
 

--- a/lib/citier/core_ext.rb
+++ b/lib/citier/core_ext.rb
@@ -29,7 +29,7 @@ class ActiveRecord::Base
 
       # set the name of the table associated to this class
       # this class will be associated to the writable table of the class_reference class
-      set_table_name(t_name)
+      self.table_name = t_name
     end
   end
 end

--- a/lib/citier/sql_adapters.rb
+++ b/lib/citier/sql_adapters.rb
@@ -16,7 +16,7 @@ begin
     module ConnectionAdapters
       class SQLiteAdapter < AbstractAdapter
 
-        def tables(name = nil) 
+        def tables(name = 'SCHEMA', table_name = nil)
           sql = <<-SQL
           SELECT name
           FROM sqlite_master
@@ -25,6 +25,7 @@ begin
           # Modification : the where clause was intially WHERE type = 'table' AND NOT name = 'sqlite_sequence' 
           #                now it is WHERE (type = 'table' or type='view') AND NOT name = 'sqlite_sequence'
           # this modification is made to consider tables AND VIEWS as tables
+          sql << " AND name = #{quote_table_name(table_name)}" if table_name
 
           execute(sql, name).map do |row|
             row['name']


### PR DESCRIPTION
A change in activerecord that breaks the sqlite_adapter in citier, so I've reflected the change in citier. 
I've also made a couple of changes to remove deprecation warnings
Other than that I've upped the version.
