### PR TITLE
Rails 3.2 deprecated methods fix

### DIFF
--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -10,7 +10,7 @@ module Citier
       #:table_name = option for setting the name of the current class table_name, default value = 'tableized(current class name)'
       table_name = (options[:table_name] || self.name.tableize.gsub(/\//,'_')).to_s
 
-      set_inheritance_column "#{db_type_field}"
+      self.inheritance_column = "#{db_type_field}"
 
       if(self.superclass!=ActiveRecord::Base)
         # Non root-class
@@ -19,7 +19,7 @@ module Citier
         citier_debug("table_name -> #{table_name}")
 
         # Set up the table which contains ALL attributes we want for this class
-        set_table_name "view_#{table_name}"
+        self.table_name = "view_#{table_name}"
 
         citier_debug("tablename (view) -> #{self.table_name}")
 
@@ -38,7 +38,7 @@ module Citier
 
         citier_debug("Root Class")
 
-        set_table_name "#{table_name}"
+        self.table_name "#{table_name}"
 
         citier_debug("table_name -> #{self.table_name}")
 

--- a/lib/citier/core_ext.rb
+++ b/lib/citier/core_ext.rb
@@ -29,7 +29,7 @@ class ActiveRecord::Base
 
       # set the name of the table associated to this class
       # this class will be associated to the writable table of the class_reference class
-      set_table_name(t_name)
+      self.table_name = t_name
     end
   end
 end


### PR DESCRIPTION
In Rails 3.2, `set_table_name` and `set_inheritance_column` are deprecated. Changed to `self.table_name=` and ``self.inheritance_column=` respectively.
