### PR TITLE
Delegate reflect_on_association to root class

### DIFF
--- a/lib/citier/class_methods.rb
+++ b/lib/citier/class_methods.rb
@@ -42,6 +42,12 @@ module Citier
 
         citier_debug("table_name -> #{self.table_name}")
 
+        # Delegate reflect_on_association to root class if a reflection not found on model class.
+        # Needed for polymorphic associations (eg friendly id :slugs)
+        define_singleton_method :reflect_on_association do |name|
+          super(name).presence || self.superclass.reflect_on_association(name)
+        end
+
         # Add the functions required for root classes only
         send :include, Citier::RootInstanceMethods
       end


### PR DESCRIPTION
Delegate reflect_on_association to the citier root class if a reflection is not found on the child class.
This is needed for polymorphic associations
The below will fail without the proposed change

```
class Node < ActiveRecord::Base
  acts_as_citier
  has_many :comments, :as => :commentable
end

class Page < Node
  acts_as_citier
end

class Comment < ActiveRecord::Base
  belongs_to :commentable, :polymorphic => true
end

Page.first.comments # NoMethodError: undefined method `association_class' for nil:NilClass
```
